### PR TITLE
Allow specifying streams (e.g. IPTV) as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 ffprobe-python module
 =====================
 
-A wrapper around the ffprobe command to extract metadata from media files.
+A wrapper around the ffprobe command to extract metadata from media files or streams.
 
-Usage::
+Usage:
 
 ```python
 #!/usr/bin/env python
 
 from ffprobe import FFProbe
 
+# Local file
 metadata=FFProbe('test-media-file.mov')
+
+# Video stream
+# metadata=FFProbe('http://some-streaming-url.com:8080/stream')
 
 for stream in metadata.streams:
     if stream.is_video():

--- a/tests/ffprobe_test.py
+++ b/tests/ffprobe_test.py
@@ -11,10 +11,36 @@ test_videos = [
     os.path.join(test_dir, './data/SampleVideo_1280x720_1mb.mp4'),
 ]
 
+# Taken from https://bitmovin.com/mpeg-dash-hls-examples-sample-streams
+test_streams = [
+    'https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8'
+]
+
 def test_video ():
     for test_video in test_videos:
         media = FFProbe(test_video)
         print('File:', test_video)
+        print('\tStreams:', len(media.streams))
+        for index, stream in enumerate(media.streams, 1):
+            print('\tStream: ', index)
+            try:
+                if stream.is_video():
+                    frame_rate = stream.frames() / stream.duration_seconds()
+                    print('\t\tFrame Rate:', frame_rate)
+                    print('\t\tFrame Size:', stream.frame_size())
+                print('\t\tDuration:', stream.duration_seconds())
+                print('\t\tFrames:', stream.frames())
+                print('\t\tIs video:', stream.is_video())
+            except FFProbeError as e:
+                print(e)
+            except Exception as e:
+                print(e)
+
+def test_stream ():
+    for test_stream in test_streams:
+        media = FFProbe(test_stream)
+        print('File:', test_stream)
         print('\tStreams:', len(media.streams))
         for index, stream in enumerate(media.streams, 1):
             print('\tStream: ', index)


### PR DESCRIPTION
```
$ pytest
test session starts 
platform linux -- Python 3.8.1, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /devel/ffprobe-python
collected 2 items

tests/ffprobe_test.py ..
[100%]

2 passed in 12.87s 
```