### PR TITLE
Fix Unicode error

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -68,7 +68,7 @@ class FFProbe:
             stream_metadata_met = False
 
             for line in iter(p.stderr.readline, b''):
-                line = line.decode('UTF-8')
+                line = line.decode('UTF-8', 'ignore')
 
                 if 'Metadata:' in line and not stream_metadata_met:
                     is_metadata = True

--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -44,7 +44,7 @@ class FFProbe:
             self.attachment = []
 
             for line in iter(p.stdout.readline, b''):
-                line = line.decode('UTF-8')
+                line = line.decode('UTF-8', 'ignore')
 
                 if '[STREAM]' in line:
                     stream = True


### PR DESCRIPTION
I sometimes get the following error on my files:
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 63: invalid start byte`
This small change fixes it