### PR TITLE
Updated line 32 ffprobe.py

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -29,7 +29,7 @@ class FFProbe:
 
         if os.path.isfile(self.path_to_video) or self.path_to_video.startswith('http'):
             if platform.system() == 'Windows':
-                cmd = ["ffprobe", "-show_streams", self.path_to_video]
+                cmd = ["ffprobe", "-show_streams", '"%s"' % self.path_to_video]
             else:
                 cmd = ["ffprobe -show_streams " + pipes.quote(self.path_to_video)]
 


### PR DESCRIPTION
For some reason, certain files hang in the ffprobe subprocess call when quotations are not present around the file name - added '"%s"' to enforce quotations