### PR TITLE
Enable support for gathering loop tag metadata from files

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -264,3 +264,22 @@ class FFStream:
             return int(self.__dict__.get('bit_rate', ''))
         except ValueError:
             raise FFProbeError('None integer bit_rate')
+    
+    def loop_start(self):
+        """
+        Returns loop_start as an integer in samples
+        """
+        try:
+            return int(self.__dict__.get('LoopStart', ''))
+        except ValueError:
+            raise FFProbeError('None integer loop_start')
+
+    def loop_end(self):
+        """
+        Returns loop_end as an integer in samples
+        """
+        try:
+            return int(self.__dict__.get('LoopEnd', ''))
+        except ValueError:
+            raise FFProbeError('None integer loop_end')
+

--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -270,7 +270,7 @@ class FFStream:
         Returns loop_start as an integer in samples
         """
         try:
-            return int(self.__dict__.get('LoopStart', ''))
+            return int(self.__dict__.get('TAG:LoopStart', None))
         except ValueError:
             raise FFProbeError('None integer loop_start')
 
@@ -279,7 +279,7 @@ class FFStream:
         Returns loop_end as an integer in samples
         """
         try:
-            return int(self.__dict__.get('LoopEnd', ''))
+            return int(self.__dict__.get('TAG:LoopEnd', None))
         except ValueError:
             raise FFProbeError('None integer loop_end')
 


### PR DESCRIPTION
This PR adds support for checking for checking and surfacing LoopStart and LoopEnd tags in files inspected. This is commonly used in video game audio to denote loop points to loop tracks within the game engine. 