### PR TITLE
Update ffprobe.py

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -117,7 +117,7 @@ class FFStream:
     """
 
     def __init__(self, data_lines):
-        for line in data_lines:
+        for line in filter(lambda l: "=" in l, data_lines):
             self.__dict__.update({key: value for key, value, *_ in [line.strip().split('=')]})
 
             try:


### PR DESCRIPTION
In apparently rare cases, the lines don't contain =, such as section headers.  When that happens, you'll get an error about not enough fields to unpack to fill the map on the next line.