### PR TITLE
added support for PurePath objects for defining source file.

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -8,6 +8,7 @@ import pipes
 import platform
 import re
 import subprocess
+from pathlib import Path
 
 from ffprobe.exceptions import FFProbeError
 
@@ -31,7 +32,10 @@ class FFProbe:
             if platform.system() == 'Windows':
                 cmd = ["ffprobe", "-show_streams", self.path_to_video]
             else:
-                cmd = ["ffprobe -show_streams " + pipes.quote(self.path_to_video)]
+                if isinstance(self.path_to_video, Path):
+                    cmd = ["ffprobe -show_streams " + self.path_to_video.as_posix()]
+                else:
+                    cmd = ["ffprobe -show_streams " + pipes.quote(self.path_to_video)]
 
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 


### PR DESCRIPTION
pipes breaks with the following error when given a Path object:
`TypeError: expected string or bytes-like object, got 'PosixPath'` 
This change addes a check for, and handles that case so that Path objects can be used directly in Posix enviroments